### PR TITLE
feat : 홈 화면 반응형 레이아웃 구현 [frontend]

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,9 +8,14 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.8.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-router-dom": "^7.4.0"
+        "react-icons": "^5.5.0",
+        "react-loading-skeleton": "^3.5.0",
+        "react-router-dom": "^7.4.0",
+        "react-spinners": "^0.15.0",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -1449,6 +1454,23 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1498,6 +1520,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -1567,6 +1602,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1638,12 +1685,80 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.120",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.120.tgz",
       "integrity": "sha512-oTUp3gfX1gZI+xfD2djr2rzQdHCwHzPQrrK0CD7WpTdF0nPdQ/INcRVjWgLdCT4a9W3jFObR9DAfsuyFQnI8CQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.1",
@@ -1959,6 +2074,41 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1974,6 +2124,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -1982,6 +2141,43 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -2010,6 +2206,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2018,6 +2226,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/ignore": {
@@ -2211,6 +2458,36 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2393,6 +2670,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2422,6 +2705,24 @@
       },
       "peerDependencies": {
         "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/react-loading-skeleton": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-3.5.0.tgz",
+      "integrity": "sha512-gxxSyLbrEAdXTKgfbpBEFZCO/P153DnqSCQau2+o6lNy1jgMRr2MmRmOzMmyrwSaSYLRB8g7b0waYPmUjz7IhQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-refresh": {
@@ -2472,6 +2773,16 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-spinners": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.15.0.tgz",
+      "integrity": "sha512-ZO3/fNB9Qc+kgpG3SfdlMnvTX6LtLmTnOogb3W6sXIaU/kZ1ydEViPfZ06kSOaEsor58C/tzXw2wROGQu3X2pA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/resolve-from": {
@@ -2662,6 +2973,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,9 +10,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.8.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.4.0"
+    "react-icons": "^5.5.0",
+    "react-loading-skeleton": "^3.5.0",
+    "react-router-dom": "^7.4.0",
+    "react-spinners": "^0.15.0",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/frontend/src/layout/Header.module.css
+++ b/frontend/src/layout/Header.module.css
@@ -14,7 +14,7 @@
 }
 
 .logo {
-  height: 35px;
+  height: 40px;
 
   transition: all 0.3s ease;
 
@@ -34,7 +34,7 @@
   position: relative;
 
   width: 100%;
-  max-width: 106px;
+  max-width: 120px;
 
   height: 100%;
 
@@ -48,7 +48,7 @@
 
 .create__study__button__text__bg {
   position: absolute;
-  top: 10px;
+  top: 14px;
 
   font-family: var(--font-jejudoldam);
   font-size: 14px;
@@ -59,7 +59,7 @@
 
 .create__study__button__text {
   position: absolute;
-  top: 12px;
+  top: 16px;
 
   font-family: var(--font-jejudoldam);
   font-size: 14px;
@@ -70,13 +70,13 @@
   transition: all 0.3s ease;
 }
 
-@media screen and (min-width: 375px) {
+@media screen and (min-width: 450px) {
   .logo {
     height: 60px;
   }
 
   .create__study__button {
-    max-width: 160px;
+    max-width: 180px;
     border-radius: 14px;
   }
 
@@ -93,7 +93,7 @@
   }
 }
 
-@media screen and (min-width: 744px) {
+@media screen and (min-width: 900px) {
   .create__study__button {
     max-width: 252px;
     border-radius: 16px;

--- a/frontend/src/pages/home/BrowseCardList.jsx
+++ b/frontend/src/pages/home/BrowseCardList.jsx
@@ -1,0 +1,158 @@
+import { ClipLoader } from 'react-spinners';
+import { getRandomStudies } from './api/home.api';
+import styles from './BrowseCardList.module.css';
+import HomeCard from './HomeCard';
+import searchIcon from '/images/icon/ic_search.svg';
+import { useEffect, useState } from 'react';
+import { RiArrowDownSFill, RiArrowUpSFill } from 'react-icons/ri';
+import Skeleton from 'react-loading-skeleton';
+import 'react-loading-skeleton/dist/skeleton.css';
+
+const BrowseCardList = () => {
+  const [studies, setStudies] = useState([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const [selected, setSelected] = useState('최근순');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const options = ['포인트 많은순', '포인트 적은순', '최신순', '오래된순'];
+
+  // TODO : 서버 api 개발 후 연동
+  const handleSort = (option) => {
+    setSelected(option);
+    setIsOpen(false);
+  };
+
+  // TODO : 서버 api 개발 후 연동
+  const handleSearch = (e) => {
+    const value = e.target.value;
+    setSearch(value);
+  };
+
+  const clickMoreStudy = async () => {
+    setIsLoading(true);
+    const data = await getRandomStudies(6);
+    setStudies((prev) => [...prev, ...data]);
+    setIsLoading(false);
+  };
+
+  useEffect(() => {
+    const fetchStudies = async () => {
+      setIsLoading(true);
+      const data = await getRandomStudies(6);
+      setStudies(data);
+      setIsLoading(false);
+    };
+    fetchStudies();
+  }, []);
+
+  return (
+    <div className={styles.browseStudyContainer}>
+      <div className={styles.title}>스터디 둘러보기</div>
+
+      <div className={styles.topContainer}>
+        <div className={styles.searchContainer}>
+          <img className={styles.searchIcon} src={searchIcon} alt='검색' />
+          <input
+            className={styles.searchInput}
+            type='text'
+            placeholder='검색'
+          />
+        </div>
+
+        <div className={styles.filterContainer}>
+          <div className={styles.dropdown} onClick={() => setIsOpen(!isOpen)}>
+            <span className={styles.selected}>{selected}</span>
+
+            {isOpen ? (
+              <span className={styles.arrow}>
+                <RiArrowUpSFill />
+              </span>
+            ) : (
+              <span className={styles.arrow}>
+                <RiArrowDownSFill />
+              </span>
+            )}
+
+            {isOpen && (
+              <ul className={styles.dropdownMenu}>
+                {options.map((option) => (
+                  <li
+                    key={option}
+                    onClick={() => {
+                      setSelected(option);
+                      setIsOpen(false);
+                    }}
+                    className={styles.dropdownItem}
+                  >
+                    {option}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className={styles.cardListContainer}>
+        <ul className={styles.cardList}>
+          {isLoading && studies.length === 0 ? (
+            <>
+              <Skeleton
+                width={350}
+                height={200}
+                enableAnimation={true}
+                style={{
+                  backgroundColor: '#e5e7eb',
+                  backgroundImage:
+                    'linear-gradient(90deg, #e5e7eb, #f3f4f6, #e5e7eb)',
+                }}
+              />
+              <Skeleton
+                width={350}
+                height={200}
+                enableAnimation={true}
+                style={{
+                  backgroundColor: '#e5e7eb',
+                  backgroundImage:
+                    'linear-gradient(90deg, #e5e7eb, #f3f4f6, #e5e7eb)',
+                }}
+              />
+              <Skeleton
+                width={350}
+                height={200}
+                enableAnimation={true}
+                style={{
+                  backgroundColor: '#e5e7eb',
+                  backgroundImage:
+                    'linear-gradient(90deg, #e5e7eb, #f3f4f6, #e5e7eb)',
+                }}
+              />
+            </>
+          ) : (
+            studies.map((data) => (
+              <div key={data.id} className={styles.cardWrapper}>
+                <HomeCard data={data} />
+              </div>
+            ))
+          )}
+        </ul>
+      </div>
+
+      <div className={styles.moreButtonContainer}>
+        <button
+          onClick={clickMoreStudy}
+          className={styles.moreButton}
+          disabled={isLoading}
+        >
+          {isLoading ? (
+            <ClipLoader size={20} color='#578246' loading={true} />
+          ) : (
+            '더보기'
+          )}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default BrowseCardList;

--- a/frontend/src/pages/home/BrowseCardList.module.css
+++ b/frontend/src/pages/home/BrowseCardList.module.css
@@ -1,0 +1,221 @@
+.browseStudyContainer {
+  width: 100%;
+  max-width: 1200px;
+  background-color: var(--bg-white);
+  padding: 20px;
+
+  border-radius: 20px;
+  transition: all 0.3s ease;
+}
+
+.topContainer {
+  display: flex;
+  flex-direction: column;
+}
+
+.title {
+  font-size: 16px;
+  font-weight: 800;
+  color: var(--text-black);
+
+  margin-bottom: 15px;
+  transition: all 0.3s ease;
+}
+
+.searchContainer {
+  width: 100%;
+  height: 42px;
+
+  display: flex;
+  align-items: center;
+
+  padding-left: 20px;
+
+  border: 1px solid #dddddd;
+  border-radius: 15px;
+}
+
+.searchInput {
+  width: 90%;
+  height: 100%;
+
+  border: none;
+
+  font-size: 16px;
+
+  padding-left: 10px;
+
+  padding-top: 5px;
+}
+
+.searchInput:focus {
+  outline: none;
+}
+
+.searchIcon {
+  width: 18px;
+  height: 18px;
+}
+
+.filterContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 180px;
+  height: 42px;
+
+  border: 1px solid #dddddd;
+
+  border-radius: 15px;
+
+  margin-top: 20px;
+  margin-bottom: 10px;
+
+  margin-left: auto;
+}
+
+.dropdown {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: relative;
+  gap: 8px;
+
+  padding: 0 16px;
+
+  width: 95%;
+
+  color: var(--text-gray);
+  background-color: var(--bg-white);
+
+  cursor: pointer;
+}
+
+.selected {
+  font-size: 14px;
+  color: var(--text-primary);
+}
+
+.arrow {
+  font-size: 20px;
+
+  color: var(--color-gray-300);
+}
+
+.dropdownMenu {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  margin-top: 20px;
+  background-color: var(--bg-white);
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+
+  padding: 10px 0;
+}
+
+.dropdownItem {
+  padding: 8px 16px;
+  font-size: 14px;
+  color: var(--text-gray);
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.dropdownItem:hover {
+  color: var(--text-blue);
+}
+
+.cardListContainer {
+  margin-top: 10px;
+  width: 100%;
+}
+
+.cardList {
+  display: grid;
+  grid-template-columns: repeat(1, 1fr);
+  gap: 20px;
+}
+
+.moreButtonContainer {
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  margin-top: 10px;
+}
+
+.moreButton {
+  width: 290px;
+  height: 53px;
+
+  font-size: 16px;
+  color: var(--text-green);
+  background: var(--bg-white);
+
+  border: 1px solid #dddddd;
+  border-radius: 25px;
+
+  margin-top: 20px;
+
+  cursor: pointer;
+
+  transition: all 0.3s ease;
+}
+.moreButton:disabled:hover {
+  background: var(--bg-white);
+  color: var(--text-green);
+}
+
+.moreButton:hover {
+  background: var(--bg-green);
+  color: var(--text-white);
+}
+
+@media screen and (min-width: 744px) {
+  .title {
+    font-size: 24px;
+  }
+  .topContainer {
+    align-items: center;
+    flex-direction: row;
+  }
+  .searchContainer {
+    width: 335px;
+  }
+
+  .filterContainer {
+    margin-top: 0;
+  }
+
+  .cardList {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  .browseStudyContainer {
+    padding: 30px;
+  }
+  .topContainer {
+    align-items: center;
+    flex-direction: row;
+  }
+  .searchContainer {
+    width: 335px;
+  }
+
+  .filterContainer {
+    margin-top: 0;
+  }
+
+  .cardList {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}

--- a/frontend/src/pages/home/Home.jsx
+++ b/frontend/src/pages/home/Home.jsx
@@ -1,14 +1,12 @@
+import BrowseCardList from './BrowseCardList';
 import styles from './Home.module.css';
+import RecentlyCardList from './RecentlyCardList';
 
 const Home = () => {
   return (
     <section className={styles.home}>
-      <div className={styles.recentStudy__container}>
-        <div className={styles.recentStudy__title}>최근 조회한 스터디</div>
-      </div>
-      <div className={styles.studyExplore__container}>
-        <div className={styles.studyExplore__title}>스터디 둘러보기</div>
-      </div>
+      <RecentlyCardList />
+      <BrowseCardList />
     </section>
   );
 };

--- a/frontend/src/pages/home/Home.module.css
+++ b/frontend/src/pages/home/Home.module.css
@@ -1,3 +1,7 @@
+* {
+  box-sizing: border-box;
+}
+
 .home {
   display: flex;
   flex-direction: column;
@@ -8,20 +12,8 @@
   gap: 20px;
 
   margin-top: 25px;
-  box-sizing: border-box;
   padding: 0 20px;
-}
+  box-sizing: border-box;
 
-.recentStudy__container {
-  width: 100%;
-  max-width: 1200px;
-  height: 100px;
-  background-color: #474747;
-}
-
-.studyExplore__container {
-  width: 100%;
-  max-width: 1200px;
-  height: 100px;
-  background-color: #5c5c5c;
+  padding-bottom: 100px;
 }

--- a/frontend/src/pages/home/HomeCard.jsx
+++ b/frontend/src/pages/home/HomeCard.jsx
@@ -1,0 +1,44 @@
+import styles from './HomeCard.module.css';
+import pointIcon from '/images/icon/ic_point.svg';
+
+const HomeCard = ({ data }) => {
+  return (
+    <li key={data.id} className={styles.card}>
+      <div className={styles.cardHeader}>
+        <div className={styles.headerTop}>
+          <div className={styles.pointsContainer}>
+            <img className={styles.pointIcon} src={pointIcon} alt='points' />
+            <span className={styles.pointsText}>{data.points}</span>
+            <span className={styles.pointsText}>획득</span>
+          </div>
+
+          <div className={styles.cardTitleContainer}>
+            {/* TODO: 조건에 따라 작성자에 색상 넣어주기 */}
+            <span>{data.author}</span>
+            <span>의</span>
+            <span>{data.title}</span>
+          </div>
+        </div>
+
+        <div className={styles.cardDayContainer}>
+          <span className={styles.cardDay}>{data.day}일째 진행 중</span>
+        </div>
+      </div>
+
+      <div className={styles.cardContentContainer}>
+        <span className={styles.cardContent}>{data.content}</span>
+      </div>
+
+      <ul className={styles.emojiContainer}>
+        {data.emoji.map((emoji) => (
+          <li key={emoji.id} className={styles.emoji}>
+            <span>{emoji.icon}</span>
+            <span>{emoji.count}</span>
+          </li>
+        ))}
+      </ul>
+    </li>
+  );
+};
+
+export default HomeCard;

--- a/frontend/src/pages/home/HomeCard.module.css
+++ b/frontend/src/pages/home/HomeCard.module.css
@@ -1,0 +1,119 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  width: 100%;
+  height: 180px;
+
+  gap: 12px;
+
+  background-color: var(--bg-green-light);
+
+  border-radius: 20px;
+
+  padding: 16px;
+
+  cursor: pointer;
+
+  transition: all 0.3s ease;
+}
+
+.cardHeader {
+  display: flex;
+  flex-direction: column;
+
+  gap: 8px;
+}
+
+.headerTop {
+  display: flex;
+  flex-direction: column;
+
+  gap: 8px;
+}
+
+.pointsContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  max-width: 80px;
+
+  gap: 5px;
+  border-radius: 20px;
+
+  padding: 3px;
+
+  border: 1px solid rgb(194, 194, 194);
+}
+
+.pointsText {
+  font-family: var(--font-pretendard-medium);
+  color: var(--text-black);
+  font-size: 12px;
+}
+
+.cardTitleContainer {
+  display: flex;
+
+  gap: 5px;
+
+  font-family: var(--font-pretendard-bold);
+  font-size: 16px;
+  color: var(--text-black);
+}
+
+.cardDayContainer {
+  font-family: var(--font-pretendard-regular);
+  font-size: 14px;
+}
+
+.cardContentContainer {
+  width: 80%;
+}
+
+.cardContent {
+  font-size: 14px;
+}
+
+.emojiContainer {
+  display: flex;
+  align-items: center;
+
+  gap: 5px;
+}
+
+.emoji {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  gap: 5px;
+
+  font-size: 12px;
+
+  padding: 8px 8px 8px 8px;
+  background-color: rgba(0, 0, 0, 0.1);
+
+  border-radius: 50px;
+}
+
+@media screen and (min-width: 744px) {
+  .card {
+    height: 220px;
+  }
+  .headerTop {
+    justify-content: space-between;
+    align-items: center;
+    flex-direction: row-reverse;
+  }
+
+  .pointsContainer {
+    width: 100%;
+  }
+
+  .cardContent {
+    font-size: 18px;
+  }
+}

--- a/frontend/src/pages/home/RecentlyCardList.jsx
+++ b/frontend/src/pages/home/RecentlyCardList.jsx
@@ -1,0 +1,398 @@
+import HomeCard from './HomeCard';
+import styles from './RecentlyCardList.module.css';
+const EXAMPLE_DATA = [
+  {
+    id: 1,
+    title: 'UX 스터디',
+    day: '62',
+    points: 310,
+    emoji: [
+      {
+        id: 1,
+        count: 37,
+        icon: '👍',
+      },
+      {
+        id: 2,
+        count: 14,
+        icon: '🔥',
+      },
+      {
+        id: 3,
+        count: 8,
+        icon: '💪',
+      },
+    ],
+    content: 'Slow And Steady Wins The Race!!',
+    author: '이유디',
+  },
+  {
+    id: 2,
+    title: 'Algorithm',
+    day: '31',
+    points: 280,
+    emoji: [
+      {
+        id: 1,
+        count: 25,
+        icon: '👍',
+      },
+      {
+        id: 2,
+        count: 18,
+        icon: '🔥',
+      },
+      {
+        id: 3,
+        count: 32,
+        icon: '💪',
+      },
+    ],
+    content: 'Solve PS',
+    author: '김코딩',
+  },
+  {
+    id: 3,
+    title: 'React Pro',
+    day: '45',
+    points: 295,
+    emoji: [
+      {
+        id: 1,
+        count: 42,
+        icon: '👍',
+      },
+      {
+        id: 2,
+        count: 21,
+        icon: '🔥',
+      },
+      {
+        id: 3,
+        count: 38,
+        icon: '💪',
+      },
+    ],
+    content: 'Advanced',
+    author: '박리액트',
+  },
+  {
+    id: 4,
+    title: 'CS Basic',
+    day: '15',
+    points: 150,
+    emoji: [
+      {
+        id: 1,
+        count: 28,
+        icon: '👍',
+      },
+      {
+        id: 2,
+        count: 12,
+        icon: '🔥',
+      },
+      {
+        id: 3,
+        count: 19,
+        icon: '💪',
+      },
+    ],
+    content: 'OS & DB',
+    author: '최컴공',
+  },
+  {
+    id: 5,
+    title: 'CS Study',
+    day: '15',
+    points: 150,
+    emoji: [
+      {
+        id: 1,
+        count: 28,
+        icon: '👍',
+      },
+      {
+        id: 2,
+        count: 12,
+        icon: '🔥',
+      },
+      {
+        id: 3,
+        count: 19,
+        icon: '💪',
+      },
+    ],
+    content: 'Theory',
+    author: '정씨에스',
+  },
+  {
+    id: 6,
+    title: 'TypeScript 마스터',
+    day: '28',
+    points: 245,
+    emoji: [
+      {
+        id: 1,
+        count: 31,
+        icon: '👍',
+      },
+      {
+        id: 2,
+        count: 15,
+        icon: '🔥',
+      },
+      {
+        id: 3,
+        count: 22,
+        icon: '💪',
+      },
+    ],
+    content: 'TS Deep Dive',
+    author: '한타입',
+  },
+  {
+    id: 7,
+    title: 'Next.js 스터디',
+    day: '40',
+    points: 320,
+    emoji: [
+      {
+        id: 1,
+        count: 45,
+        icon: '👍',
+      },
+      {
+        id: 2,
+        count: 28,
+        icon: '🔥',
+      },
+      {
+        id: 3,
+        count: 33,
+        icon: '💪',
+      },
+    ],
+    content: 'SSR Master',
+    author: '김넥스트',
+  },
+  {
+    id: 8,
+    title: 'Python 기초',
+    day: '20',
+    points: 180,
+    emoji: [
+      {
+        id: 1,
+        count: 22,
+        icon: '👍',
+      },
+      {
+        id: 2,
+        count: 11,
+        icon: '🔥',
+      },
+      {
+        id: 3,
+        count: 16,
+        icon: '💪',
+      },
+    ],
+    content: 'Basic Python',
+    author: '박파이썬',
+  },
+  {
+    id: 9,
+    title: 'Node.js 백엔드',
+    day: '35',
+    points: 275,
+    emoji: [
+      {
+        id: 1,
+        count: 33,
+        icon: '👍',
+      },
+      {
+        id: 2,
+        count: 19,
+        icon: '🔥',
+      },
+      {
+        id: 3,
+        count: 25,
+        icon: '💪',
+      },
+    ],
+    content: 'Backend Dev',
+    author: '이노드',
+  },
+  {
+    id: 10,
+    title: 'Docker 실전',
+    day: '25',
+    points: 230,
+    emoji: [
+      {
+        id: 1,
+        count: 29,
+        icon: '👍',
+      },
+      {
+        id: 2,
+        count: 16,
+        icon: '🔥',
+      },
+      {
+        id: 3,
+        count: 21,
+        icon: '💪',
+      },
+    ],
+    content: 'Container',
+    author: '최도커',
+  },
+  {
+    id: 11,
+    title: 'AWS 클라우드',
+    day: '50',
+    points: 340,
+    emoji: [
+      {
+        id: 1,
+        count: 48,
+        icon: '👍',
+      },
+      {
+        id: 2,
+        count: 31,
+        icon: '🔥',
+      },
+      {
+        id: 3,
+        count: 36,
+        icon: '💪',
+      },
+    ],
+    content: 'Cloud Infra',
+    author: '정클라우드',
+  },
+  {
+    id: 12,
+    title: 'Vue.js 입문',
+    day: '22',
+    points: 195,
+    emoji: [
+      {
+        id: 1,
+        count: 24,
+        icon: '👍',
+      },
+      {
+        id: 2,
+        count: 13,
+        icon: '🔥',
+      },
+      {
+        id: 3,
+        count: 18,
+        icon: '💪',
+      },
+    ],
+    content: 'Vue Basic',
+    author: '김뷰',
+  },
+  {
+    id: 13,
+    title: '데이터베이스',
+    day: '33',
+    points: 260,
+    emoji: [
+      {
+        id: 1,
+        count: 35,
+        icon: '👍',
+      },
+      {
+        id: 2,
+        count: 20,
+        icon: '🔥',
+      },
+      {
+        id: 3,
+        count: 27,
+        icon: '💪',
+      },
+    ],
+    content: 'SQL Master',
+    author: '이디비',
+  },
+  {
+    id: 14,
+    title: '머신러닝 기초',
+    day: '45',
+    points: 310,
+    emoji: [
+      {
+        id: 1,
+        count: 41,
+        icon: '👍',
+      },
+      {
+        id: 2,
+        count: 25,
+        icon: '🔥',
+      },
+      {
+        id: 3,
+        count: 32,
+        icon: '💪',
+      },
+    ],
+    content: 'ML Basic',
+    author: '박머신',
+  },
+  {
+    id: 15,
+    title: '웹 보안',
+    day: '30',
+    points: 255,
+    emoji: [
+      {
+        id: 1,
+        count: 32,
+        icon: '👍',
+      },
+      {
+        id: 2,
+        count: 17,
+        icon: '🔥',
+      },
+      {
+        id: 3,
+        count: 23,
+        icon: '💪',
+      },
+    ],
+    content: 'Security',
+    author: '최보안',
+  },
+];
+
+const RecentlyCardList = () => {
+  return (
+    <div className={styles.recentStudyContainer}>
+      <div className={styles.title}>최근 조회한 스터디</div>
+      <div className={styles.cardListContainer}>
+        <ul className={styles.cardList}>
+          {EXAMPLE_DATA.map((data) => (
+            <div key={data.id} className={styles.cardWrapper}>
+              <HomeCard data={data} />
+            </div>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default RecentlyCardList;

--- a/frontend/src/pages/home/RecentlyCardList.module.css
+++ b/frontend/src/pages/home/RecentlyCardList.module.css
@@ -1,0 +1,61 @@
+.recentStudyContainer {
+  width: 100%;
+  max-width: 1200px;
+  background-color: var(--bg-white);
+  padding: 20px 0 20px 20px;
+
+  border-radius: 20px;
+}
+
+.title {
+  font-size: 16px;
+  font-weight: 800;
+  color: var(--text-black);
+
+  margin-bottom: 15px;
+
+  transition: all 0.3s ease;
+}
+
+.cardListContainer {
+  overflow-x: auto;
+  overflow-y: hidden;
+
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.cardListContainer::-webkit-scrollbar {
+  display: none;
+}
+
+.cardList {
+  display: flex;
+  width: max-content;
+
+  gap: 20px;
+
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.cardWrapper {
+  width: 300px;
+
+  transition: width 0.3s ease;
+}
+
+@media screen and (min-width: 744px) {
+  .recentStudyContainer {
+    padding: 30px 0 30px 30px;
+  }
+  .title {
+    font-size: 24px;
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  .cardWrapper {
+    width: 374.5px;
+  }
+}

--- a/frontend/src/pages/home/api/home.api.js
+++ b/frontend/src/pages/home/api/home.api.js
@@ -1,0 +1,141 @@
+import { v4 as uuidv4 } from 'uuid';
+
+// 랜덤 제목 생성을 위한 데이터
+const STUDY_TOPICS = [
+  'React',
+  'JavaScript',
+  'TypeScript',
+  'Node.js',
+  'Python',
+  'Algorithm',
+  'CS 기초',
+  'UX/UI',
+  'AWS',
+  'Docker',
+  'Vue.js',
+  'Angular',
+  'Spring',
+  'Java',
+  'Kotlin',
+  'iOS',
+  'Android',
+  'Flutter',
+  'Go',
+  'Rust',
+];
+
+const STUDY_TYPES = ['스터디', '프로젝트', '챌린지', '모각코'];
+
+const CONTENT_LIST = [
+  '함께 성장해요!',
+  '초보자 환영!',
+  '실전 프로젝트',
+  'Step by Step',
+  '기초부터 심화까지',
+  '실무 능력 향상',
+  '취업 준비',
+  '포트폴리오 준비',
+  '1일 1커밋',
+  '주 3회 스터디',
+];
+
+const AUTHOR_SURNAMES = [
+  '김',
+  '이',
+  '박',
+  '최',
+  '정',
+  '강',
+  '조',
+  '윤',
+  '장',
+  '임',
+];
+const AUTHOR_NICKNAMES = [
+  '개발자',
+  '코더',
+  '프로',
+  '마스터',
+  '고수',
+  '러버',
+  '킹',
+  '챔프',
+  '히어로',
+  '메이커',
+];
+
+// 랜덤 숫자 생성 함수
+const getRandomNumber = (min, max) => {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+};
+
+// 랜덤 이모지 데이터 생성
+const generateEmojis = () => {
+  return [
+    {
+      id: 1,
+      count: getRandomNumber(10, 50),
+      icon: '👍',
+    },
+    {
+      id: 2,
+      count: getRandomNumber(5, 40),
+      icon: '🔥',
+    },
+    {
+      id: 3,
+      count: getRandomNumber(8, 45),
+      icon: '💪',
+    },
+  ];
+};
+
+// 랜덤 스터디 데이터 생성
+const generateRandomStudy = () => {
+  const topic = STUDY_TOPICS[Math.floor(Math.random() * STUDY_TOPICS.length)];
+  const type = STUDY_TYPES[Math.floor(Math.random() * STUDY_TYPES.length)];
+  const surname =
+    AUTHOR_SURNAMES[Math.floor(Math.random() * AUTHOR_SURNAMES.length)];
+  const nickname =
+    AUTHOR_NICKNAMES[Math.floor(Math.random() * AUTHOR_NICKNAMES.length)];
+
+  return {
+    id: uuidv4(),
+    title: `${topic} ${type}`,
+    day: getRandomNumber(1, 100).toString(),
+    points: getRandomNumber(100, 500),
+    emoji: generateEmojis(),
+    content: CONTENT_LIST[Math.floor(Math.random() * CONTENT_LIST.length)],
+    author: `${surname}${nickname}`,
+  };
+};
+
+// API 함수
+export const getRandomStudies = (count = 10) => {
+  // 실제 API 호출을 시뮬레이션하기 위한 Promise 사용
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      const studies = Array.from({ length: count }, (_, index) =>
+        generateRandomStudy()
+      );
+      resolve(studies);
+    }, 300); // 0.5초 지연
+  });
+};
+
+// 정렬 함수들
+export const sortByRecent = (studies) => {
+  return [...studies].sort((a, b) => parseInt(b.day) - parseInt(a.day));
+};
+
+export const sortByPopular = (studies) => {
+  return [...studies].sort((a, b) => {
+    const aTotal = a.emoji.reduce((sum, e) => sum + e.count, 0);
+    const bTotal = b.emoji.reduce((sum, e) => sum + e.count, 0);
+    return bTotal - aTotal;
+  });
+};
+
+export const sortByPoints = (studies) => {
+  return [...studies].sort((a, b) => b.points - a.points);
+};


### PR DESCRIPTION
# 📌 개요
홈 화면의 레이아웃을 반응형으로 구현하여 데스크탑, 태블릿, 모바일 환경에 맞춰 각 UI 요소가 자연스럽게 정렬되도록 개선했습니다.

# ✅ 기능 내용
홈 화면의 반응형 레이아웃 구현

각 해상도에 맞는 카드 그리드 열 수, UI 정렬 방식, 크기 및 위치 조정

최근 조회한 스터디와 스터디 둘러보기 섹션 포함

# 🔍 상세 내용
데스크탑: 카드 섹션이 3열 그리드로 정렬

태블릿 (예: iPad mini): 카드 섹션이 2열 그리드로 정렬

모바일: 카드가 1열로 세로 정렬

검색창과 정렬 드롭다운은 각 해상도에 맞게 위치 조정 및 스타일 적용

각 카드의 콘텐츠(텍스트, 아이콘, 버튼 등)는 해상도에 따라 폰트 크기, 정렬 방식, 줄바꿈 처리 등을 적용하여 자연스럽게 보이도록 구현

‘더보기’ 버튼은 각 화면 크기에 따라 가운데 정렬/풀 너비/적절한 마진 등 반응형 스타일을 적용

📐 CSS 방식: CSS Module + Media Query 기반 반응형 구현

Closes #8 