### PR TITLE
feat : 기존 레이아웃 구조에서 리액트 라우터의 Outlet을 이용한 레이아웃 구조로 변경 [Frontend]

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,20 +1,19 @@
-import React from "react";
-import { Routes, Route } from "react-router-dom";
-import "../public/font/Pretendard-1.3.9/web/static/pretendard.css";
-import Header from "./layout/Header";
-import Home from "@home/Home";
-import TodayFocus from "@today-focus/TodayFocus";
-import TodayHabit from "@today-habit/TodayHabit";
-import StudyDetail from "@study-detail/StudyDetail";
-import StudyCreate from "@study-create/StudyCreate";
-import StudyEditForm from "@study-detail/study-edit-form/StudyEditForm";
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+import '../public/font/Pretendard-1.3.9/web/static/pretendard.css';
+import Home from '@home/Home';
+import TodayFocus from '@today-focus/TodayFocus';
+import TodayHabit from '@today-habit/TodayHabit';
+import StudyDetail from '@study-detail/StudyDetail';
+import StudyCreate from '@study-create/StudyCreate';
+import StudyEditForm from '@study-detail/study-edit-form/StudyEditForm';
+import Layout from './layout/Layout';
 
 function App() {
   return (
     <>
-      <Header />
-      <main>
-        <Routes>
+      <Routes>
+        <Route element={<Layout />}>
           <Route path="/" element={<Home />} />
           <Route path="/study/*">
             <Route path="create" element={<StudyCreate />} />
@@ -23,8 +22,8 @@ function App() {
             <Route path=":id/focus" element={<TodayFocus />} />
             <Route path=":id/habit" element={<TodayHabit />} />
           </Route>
-        </Routes>
-      </main>
+        </Route>
+      </Routes>
     </>
   );
 }

--- a/frontend/src/layout/Header.jsx
+++ b/frontend/src/layout/Header.jsx
@@ -1,14 +1,14 @@
-import React, { useEffect, useState } from "react";
-import styles from "./Header.module.css";
-import logo1 from "/images/logo/logo_icon.svg";
-import { Link, useLocation } from "react-router-dom";
+import React, { useEffect, useState } from 'react';
+import styles from './Header.module.css';
+import logo1 from '/images/logo/logo_icon.svg';
+import { Link, useLocation } from 'react-router-dom';
 
 const Header = () => {
   const [isOpen, setIsOpen] = useState(false);
   const location = useLocation();
 
   useEffect(() => {
-    if (location.pathname === "/" || location.pathname === "/study-create") {
+    if (location.pathname === '/' || location.pathname === '/study/create') {
       setIsOpen(true);
     } else {
       setIsOpen(false);
@@ -38,11 +38,11 @@ const Header = () => {
 
       {/* TODO: 작업용 임시 네비게이션 메뉴 입니다. 나중에 삭제해야 합니다. */}
 
-      {location.pathname === "/" && (
+      {location.pathname === '/' && (
         <div className={styles.nav}>
           <ul className={styles.nav__list}>
             <li className={styles.nav__item}>
-              <Link to="/study-detail" className={styles.nav__link}>
+              <Link to="/study/10" className={styles.nav__link}>
                 스터디 상세
               </Link>
             </li>
@@ -54,7 +54,7 @@ const Header = () => {
             </li>
 
             <li className={styles.nav__item}>
-              <Link to="/today-focus" className={styles.nav__link}>
+              <Link to="/study/10/focus" className={styles.nav__link}>
                 오늘의 집중
               </Link>
             </li>

--- a/frontend/src/layout/Layout.jsx
+++ b/frontend/src/layout/Layout.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Header from './Header';
+import { Outlet } from 'react-router-dom';
+
+const Layout = () => {
+  return (
+    <>
+      <Header />
+      <main>
+        <Outlet />
+      </main>
+    </>
+  );
+};
+
+export default Layout;


### PR DESCRIPTION
# 변경점
- 기존 Routes 외부에 존재하던 Header를 Layout 컴포넌트로 추출 후 react-router의 Outlet 기능을 이용해서 구현하도록 수정했습니다