### PR TITLE
refactor : UI css 피드백 사항 수정

### DIFF
--- a/frontend/src/components/home/HomeCard.jsx
+++ b/frontend/src/components/home/HomeCard.jsx
@@ -71,7 +71,7 @@ const HomeCard = ({ data }) => {
           <div className={styles.cardTitleContainer}>
             <span className={styles.cardTitle}>
               <span className={styles.authorName}>{data.nickName}</span>
-              <span> 의 {data.title}</span>
+              <span>의 {data.title}</span>
             </span>
           </div>
         </div>
@@ -91,7 +91,7 @@ const HomeCard = ({ data }) => {
         <ul className={styles.emojiContainer}>
           {data.emojis.slice(0, 3).map((emoji) => (
             <li key={emoji.id} className={styles.emoji}>
-              <span>{emoji.emojiContent}</span>
+              <span className={styles.emojiContent}>{emoji.emojiContent}</span>
               <span>{emoji.count}</span>
             </li>
           ))}

--- a/frontend/src/components/home/HomeCard.module.css
+++ b/frontend/src/components/home/HomeCard.module.css
@@ -5,7 +5,7 @@
   gap: 12px;
   width: 100%;
   height: 240px;
-  padding: 30px;
+  padding: 16px;
   border: 1px solid #dddddd;
   border-radius: 20px;
   cursor: pointer;
@@ -55,14 +55,14 @@
   z-index: 1;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 4px;
 }
 
 .headerTop {
   display: flex;
   flex-direction: column;
   align-items: start;
-  gap: 4px;
+  gap: 6px;
 }
 
 .pointsContainer {
@@ -76,7 +76,7 @@
 
   border-radius: 20px;
   border: 1px solid rgb(223, 223, 223);
-  padding: 4px 12px;
+  padding: 4px 8px;
 }
 
 .pointsTextContainer {
@@ -211,11 +211,19 @@
   display: flex;
   align-items: center;
   justify-content: center;
+
   gap: 5px;
   font-size: 12px;
   padding: 6px 8px;
   background-color: rgba(0, 0, 0, 0.4);
   border-radius: 50px;
+}
+
+.emojiContent {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 12px;
 }
 
 .card[data-bg="bg5"] .emoji,

--- a/frontend/src/layout/Header.module.css
+++ b/frontend/src/layout/Header.module.css
@@ -1,7 +1,7 @@
 .container {
   display: flex;
   justify-content: center;
-  padding: 30px 16px;
+  padding: 20px 16px;
 }
 
 .header__wrapper {

--- a/frontend/src/pages/home/BrowseCardList.module.css
+++ b/frontend/src/pages/home/BrowseCardList.module.css
@@ -22,7 +22,8 @@
   justify-content: center;
   height: 600px;
   color: var(--text-gray);
-  font-size: 20px;
+  font-size: 16px;
+  font-weight: 500;
 }
 
 @media screen and (min-width: 744px) {
@@ -30,9 +31,13 @@
     grid-template-columns: repeat(2, 1fr);
     gap: 24px;
   }
+
+  .noData {
+    font-size: 20px;
+  }
 }
 
-@media screen and (min-width: 1200px) {
+@media screen and (min-width: 1250px) {
   .cardList {
     grid-template-columns: repeat(3, 357px);
   }

--- a/frontend/src/pages/home/BrowseSection.module.css
+++ b/frontend/src/pages/home/BrowseSection.module.css
@@ -58,7 +58,7 @@
 
 @media screen and (min-width: 744px) {
   .browseStudyContainer {
-    padding: 40px;
+    padding: 24px;
   }
 
   .title {
@@ -71,5 +71,14 @@
     justify-content: space-between;
 
     margin-bottom: 24px;
+  }
+  .moreButtonContainer {
+    margin-top: 60px;
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  .browseStudyContainer {
+    padding: 40px;
   }
 }

--- a/frontend/src/pages/home/Home.module.css
+++ b/frontend/src/pages/home/Home.module.css
@@ -13,3 +13,16 @@
 
   padding-bottom: 40px;
 }
+
+@media screen and (min-width: 744px) {
+  .home {
+    gap: 24px;
+    padding: 0 24px;
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  .home {
+    gap: 40px;
+  }
+}

--- a/frontend/src/pages/home/RecentlySection.module.css
+++ b/frontend/src/pages/home/RecentlySection.module.css
@@ -25,7 +25,8 @@
   justify-content: center;
   height: 380px;
   color: var(--text-gray);
-  font-size: 20px;
+  font-size: 16px;
+  font-weight: 500;
 }
 
 .cardListContainer {
@@ -57,7 +58,7 @@
 
 @media screen and (min-width: 744px) {
   .recentStudyContainer {
-    padding: 40px 40px 30px 40px;
+    padding: 24px 24px 16px 24px;
   }
 
   .title {
@@ -71,10 +72,17 @@
   .cardList {
     gap: 24px;
   }
+  .noData {
+    font-size: 20px;
+  }
 }
 
 @media screen and (min-width: 1200px) {
   .title {
     margin-bottom: 20px;
+  }
+
+  .recentStudyContainer {
+    padding: 40px 40px 30px 40px;
   }
 }

--- a/frontend/src/pages/home/SortDropdown.module.css
+++ b/frontend/src/pages/home/SortDropdown.module.css
@@ -37,7 +37,9 @@
 }
 
 .arrow {
-  font-size: 20px;
+  width: 24px;
+  height: 24px;
+  font-size: 24px;
 
   color: var(--color-gray-300);
 }


### PR DESCRIPTION




## 🔧 UI QA 반영: Mobile / Tablet / PC 뷰 스타일 수정

디자인 QA 피드백을 바탕으로 주요 레이아웃 및 카드 스타일 수정 작업을 진행했습니다.  
기기별 수정 항목은 아래와 같으며, 보류 항목은 가장 하단에 명시했습니다.

---

### ✅ Mobile

- `<home>`
  - [x] margin 값 수정
  - [x] gap: 40px → 16px
- `<recentStudyContainer>`, `<browserStudyContainer>`
  - [x] padding: 20px → 16px
- "아직 조회한 스터디가 없어요", "아직 둘러 볼 스터디가 없어요"
  - [x] font-size: 20px → 16px
  - [x] font-weight: 500 적용
- `topContainer`
  - [x] margin, gap 조정
- `<card>`
  - [x] padding: 30px → 16px

---

### ✅ 최근 조회한 스터디 (카드 있을 경우)

- `<cardListContainer>`
  - [x] margin: 40px → 16px
- `<cardHeaderContainer>`
  - [x] gap: 8px → 4px
- `<headerTop>`
  - [x] gap: 4px → 6px
- 이모지 아이콘
  - [x] width/height: 12px 적용
- `<cardList>`
  - [x] gap: 30px → 16px
- `<filterContainer>`
  - [x] margin-top/bottom: 12px
- `<card>`
  - [x] width: 312px 고정
  - [x] height: 180px 고정
  - [x] 타이틀에 ‘의’ 추가

---

### ✅ Tablet

- `<home>`
  - [x] margin/padding: 20px 24px
  - [x] gap: 40px → 24px
- `<recentStudyContainer>`
  - [x] padding 축소
- "아직 조회한 스터디가 없습니다"
  - [x] font-size: 20px 유지
- `<browserStudyContainer>`
  - [x] padding: 40px 24px
- 스터디 둘러보기 텍스트
  - [x] margin-bottom 제거
- `<filterContainer>`
  - [x] width: 150px → auto
  - [x] padding: 9px 20px 적용
- `<arrow>` 아이콘
  - [x] width/height: 24px 적용
- 더보기 버튼
  - [x] mt-60 (브라우저/태블릿), mt-30 (모바일)

---

### ✅ PC

- `<layout>`
  - [x] padding: 30px 16px → 20px 16px
- `<home>`
  - [x] section 사이 gap 조정

---

### 📝 참고 사항

- 모든 변경사항은 최신 디자인 시안 기준에 맞춤
- 반복되는 레이아웃 스타일 정리 및 고정값 최소화
- 이후 애니메이션 대응, 반응형 QA 추가 예정
