### PR TITLE
Feature - 스터디 상세화면 정보 불러오기 완료, 비밀번호 삭제 토스트 모달 구현

### DIFF
--- a/backend/src/modules/habit/habits.module.js
+++ b/backend/src/modules/habit/habits.module.js
@@ -9,6 +9,7 @@ habitsRouter.get("/:studyId/habits", async (req, res, next) => {
     const includeDeletedHabit = req.query.all === "true";
     const habits = await prisma.habit.findMany({
       where: { studyId, ...(includeDeletedHabit ? {} : { isDone: false }) },
+      include: { HabitDone: true },
     });
     res.status(201).json(habits);
   } catch (e) {

--- a/frontend/src/components/delete-study-modal/DeleteStudyModal.jsx
+++ b/frontend/src/components/delete-study-modal/DeleteStudyModal.jsx
@@ -12,7 +12,7 @@ const DeleteStudyModal = ({ isOpen, onClose }) => {
   const [showErrorToast, setShowErrorToast] = useState(false);
   const [showSuccessToast, setShowSuccessToast] = useState(false);
   const navigate = useNavigate();
-  const { id } = useParams();
+  const { studyId } = useParams();
 
   // 모달 오픈시 폼과 토스트 메세지 리셋
   useEffect(() => {
@@ -28,17 +28,17 @@ const DeleteStudyModal = ({ isOpen, onClose }) => {
   useEffect(() => {
     const fetchStudyDetail = async () => {
       try {
-        const study = await getStudyDetail(id);
+        const study = await getStudyDetail(studyId);
         setStudyTitle(study.title);
       } catch (error) {
-        console.error("스터디 기능 불러오기에서 에러가 발생하였습니다", error);
+        console.error("스터디 불러오기 에러:", error);
       }
     };
 
-    if (isOpen && id) {
+    if (isOpen && studyId) {
       fetchStudyDetail();
     }
-  }, [isOpen, id]);
+  }, [isOpen, studyId]);
 
   if (!isOpen) return null;
 
@@ -51,7 +51,6 @@ const DeleteStudyModal = ({ isOpen, onClose }) => {
       setErrorMessage("비밀번호를 입력해주세요.");
       setShowErrorToast(true);
 
-      // 3초 후 토스트 메시지 숨기기
       setTimeout(() => {
         setShowErrorToast(false);
       }, 3000);
@@ -60,26 +59,22 @@ const DeleteStudyModal = ({ isOpen, onClose }) => {
     }
 
     try {
-      // 삭제 프론트 API 함수 호출 - 백엔드 스터디 삭제 API 에서 비밀번호 검증도 함께 수행됨
-      const deleteResponse = await deleteStudy(id, password);
+      const deleteResponse = await deleteStudy(studyId, password);
 
       if (deleteResponse && deleteResponse.success) {
-        // 삭제 성공 토스트 표시
         setShowSuccessToast(true);
 
-        // 삭제 성공시 localStorage 업데이트하여 현재 삭제한 id를 가지고있는 parsedData에 일치하는 스터디 있으면 걸러서 안보이게
         const storedData = localStorage.getItem("studyForest");
         if (storedData) {
           const parsedData = JSON.parse(storedData);
           const updatedData = parsedData.filter(
-            (study) => study.id != parseInt(id)
+            (study) => study.id != parseInt(studyId)
           );
           localStorage.setItem("studyForest", JSON.stringify(updatedData));
         }
 
-        // 2초 후 홈으로 이동
         setTimeout(() => {
-          navigate("/"); // 삭제 성공 시 공부의 숲 홈으로 이동
+          navigate("/");
         }, 2000);
       } else {
         setErrorMessage(
@@ -87,7 +82,6 @@ const DeleteStudyModal = ({ isOpen, onClose }) => {
         );
         setShowErrorToast(true);
 
-        // 3초 후 토스트 메시지 숨기기
         setTimeout(() => {
           setShowErrorToast(false);
         }, 3000);
@@ -98,7 +92,6 @@ const DeleteStudyModal = ({ isOpen, onClose }) => {
       setErrorMessage(errorMsg || "스터디 삭제 중 오류가 발생했습니다.");
       setShowErrorToast(true);
 
-      // 3초 후 토스트 메시지 숨기기
       setTimeout(() => {
         setShowErrorToast(false);
       }, 3000);
@@ -106,29 +99,28 @@ const DeleteStudyModal = ({ isOpen, onClose }) => {
   };
 
   return (
-    <div className={styles.modalOverlay}>
-      <div className={styles.modalContent}>
-        <div className={styles.modalHeader}>
-          <p className={styles.modalTitle}>{studyTitle}</p>
+    <div className={styles.overlay}>
+      <div className={styles.content}>
+        <div className={styles.header}>
+          <p className={styles.title}>{studyTitle}</p>
           <button
             type="button"
             onClick={onClose}
-            className={styles.modalCloseButton}
+            className={styles.closeButton}
           >
             나가기
           </button>
         </div>
-        <p className={styles.modalMessage}>권한이 필요해요!</p>
-        <div className={styles.modalInputContainer}>
-          <p className={styles.modalInputLabel}>비밀번호</p>
+        <p className={styles.message}>권한이 필요해요!</p>
+        <div className={styles.inputContainer}>
+          <p className={styles.inputLabel}>비밀번호</p>
           <input
             placeholder="비밀번호를 입력해 주세요"
             type="password"
             value={password}
             onChange={handlePasswordChange}
-            className={styles.modalInput}
+            className={styles.input}
           />
-          {/* 토스트 컴포넌트 추가 */}
           <DeleteStudyToast
             error={showErrorToast}
             success={showSuccessToast}
@@ -136,7 +128,7 @@ const DeleteStudyModal = ({ isOpen, onClose }) => {
           />
         </div>
         <button
-          className={`${styles.modalVerifyButton}`}
+          className={styles.deleteButton}
           type="button"
           onClick={handleDeleteStudy}
         >

--- a/frontend/src/components/delete-study-modal/DeleteStudyModal.module.css
+++ b/frontend/src/components/delete-study-modal/DeleteStudyModal.module.css
@@ -1,4 +1,4 @@
-.modalOverlay {
+.overlay {
   position: fixed;
   top: 0;
   left: 0;
@@ -11,21 +11,17 @@
   z-index: 1000;
 }
 
-.modalContent {
+.content {
   background-color: var(--color-white);
-  padding: 20px;
   border-radius: var(--radius-sm);
   width: 344px;
-  height: 341px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
   display: flex;
   flex-direction: column;
-  align-items: stretch;
-  gap: 20px;
   padding: 24px 16px;
 }
 
-.modalHeader {
+.header {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -33,14 +29,14 @@
   margin-top: 24px;
 }
 
-.modalTitle {
+.title {
   font-size: 24px;
   font-weight: bold;
+  text-align: center;
   flex-grow: 1;
-  margin-left: 218px;
 }
 
-.modalCloseButton {
+.closeButton {
   background: none;
   border: none;
   font-size: 16px;
@@ -48,32 +44,31 @@
   color: var(--color-green-300);
 }
 
-.modalMessage {
+.message {
   margin-bottom: 20px;
   text-align: center;
   color: var(--color-gray-300);
 }
 
-.modalInputContainer {
+.inputContainer {
   margin-bottom: 15px;
 }
 
-.modalInputLabel {
+.inputLabel {
   display: block;
   margin-bottom: 6px;
   font-weight: bold;
 }
 
-.modalInput {
+.input {
   width: 100%;
-  padding: 8px;
   border: 1px solid #ccc;
   border-radius: var(--radius-sm);
   margin-top: 10px;
   padding: 14px;
 }
 
-.modalVerifyButton {
+.deleteButton {
   font-family: var(--font-jejudoldam);
   background-color: var(--color-green-200);
   color: var(--color-white);
@@ -82,26 +77,23 @@
   border-radius: var(--radius-sm);
   cursor: pointer;
   font-size: 18px;
-  width: 312px;
+  width: 100%;
   height: 58px;
+  margin-top: 10px;
 }
 
-.modalVerifyButton:hover {
+.deleteButton:hover {
   background-color: var(--color-green-300);
 }
 
-.errorMessage {
+.error {
   color: var(--color-red-300);
   margin-top: 8px;
 }
 
 @media screen and (min-width: 744px) {
-  .modalVerifyButton {
-    width: 600px;
-  }
-  .modalContent {
+  .content {
     width: 648px;
-    height: 369px;
     padding: 40px 24px;
   }
 }

--- a/frontend/src/components/delete-study-modal/DeleteStudyToast.jsx
+++ b/frontend/src/components/delete-study-modal/DeleteStudyToast.jsx
@@ -1,4 +1,3 @@
-// DeleteStudyToast.jsx
 import React from "react";
 import styles from "./DeleteStudyToast.module.css";
 
@@ -9,7 +8,7 @@ const DeleteStudyToast = ({ error, success, message }) => {
         🚨 {message || "비밀번호가 일치하지 않습니다."}
       </p>
       <p className={`${styles.toastSuccess} ${success && styles.show}`}>
-        🎉 스터디가 성공적으로 삭제되었습니다!
+        🎉 스터디가 성공적으로 삭제되었습니다
       </p>
     </aside>
   );

--- a/frontend/src/components/delete-study-modal/DeleteStudyToast.jsx
+++ b/frontend/src/components/delete-study-modal/DeleteStudyToast.jsx
@@ -1,0 +1,18 @@
+// DeleteStudyToast.jsx
+import React from "react";
+import styles from "./DeleteStudyToast.module.css";
+
+const DeleteStudyToast = ({ error, success, message }) => {
+  return (
+    <aside className={styles.toastContainer}>
+      <p className={`${styles.toastError} ${error && styles.show}`}>
+        🚨 {message || "비밀번호가 일치하지 않습니다."}
+      </p>
+      <p className={`${styles.toastSuccess} ${success && styles.show}`}>
+        🎉 스터디가 성공적으로 삭제되었습니다!
+      </p>
+    </aside>
+  );
+};
+
+export default DeleteStudyToast;

--- a/frontend/src/components/delete-study-modal/DeleteStudyToast.module.css
+++ b/frontend/src/components/delete-study-modal/DeleteStudyToast.module.css
@@ -1,0 +1,75 @@
+.toastContainer {
+  position: fixed;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  left: 0;
+  bottom: 24px;
+  z-index: 10000;
+}
+
+.toastError {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 260px;
+  height: 45px;
+  border-radius: 12px;
+  background-color: var(--bg-pink);
+  color: var(--error-light);
+  font-weight: 500;
+  font-size: 14px;
+  position: absolute;
+  bottom: 0;
+  visibility: hidden;
+  opacity: 0;
+  transform: translateY(40px);
+  transition: opacity 500ms, visibility 0ms 500ms, transform 500ms ease-in-out;
+}
+
+.toastError.show {
+  visibility: visible;
+  opacity: 1;
+  transform: translateY(-20px);
+  transition: opacity 500ms, visibility 0ms, transform 500ms ease-in-out;
+}
+
+.toastSuccess {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 260px;
+  height: 45px;
+  border-radius: 12px;
+  background-color: var(--bg-green-light);
+  color: var(--text-green);
+  font-weight: 500;
+  font-size: 14px;
+  position: absolute;
+  bottom: 0;
+  visibility: hidden;
+  opacity: 0;
+  transform: translateY(40px);
+  transition: opacity 500ms, visibility 0ms 500ms, transform 500ms ease-in-out;
+}
+
+.toastSuccess.show {
+  visibility: visible;
+  opacity: 1;
+  transform: translateY(-20px);
+  transition: opacity 500ms, visibility 0ms, transform 500ms ease-in-out;
+}
+
+@media (min-width: 744px) {
+  .toastContainer {
+    bottom: 40px;
+  }
+
+  .toastError,
+  .toastSuccess {
+    width: 300px;
+    height: 47px;
+    font-size: 16px;
+  }
+}

--- a/frontend/src/pages/study-detail/HabitRecordTable.jsx
+++ b/frontend/src/pages/study-detail/HabitRecordTable.jsx
@@ -60,10 +60,6 @@ function HabitRecordTable() {
         // 현재 스터디에 해당하는 습관들의 완료상태를 정리한 객체를 생성
         const completions = processHabitCompletions(habitData, weekDates);
         setHabitCompletions(completions);
-
-        console.log("habit data 가져온것:", habitData);
-        console.log("this week date:", weekDates);
-        console.log("habit completion status:", completions);
       } catch (error) {
         console.error("Habit 데이터 가져오는데 에러발생:", error);
       } finally {
@@ -78,15 +74,9 @@ function HabitRecordTable() {
 
   // 습관별 완료 상태 처리 함수
   const processHabitCompletions = (habits, weekDates) => {
-    console.log("processHabitCompletions 실행, habits:", habits);
-    console.log("processHabitCompletions 실행, weekDates:", weekDates);
-
     const completions = {};
 
     habits.forEach((habit) => {
-      console.log(`습관 ID ${habit.id}, 제목: ${habit.title} 처리 중...`);
-      console.log(`이 습관의 HabitDone:`, habit.HabitDone);
-
       completions[habit.id] = {};
 
       // completions 초기화
@@ -96,18 +86,13 @@ function HabitRecordTable() {
 
       if (habit.HabitDone && habit.HabitDone.length > 0) {
         habit.HabitDone.forEach((done) => {
-          console.log(`HabitDone 기록:`, done);
           const doneDate =
             done.createdAt instanceof Date
               ? done.createdAt.toISOString().split("T")[0]
               : String(done.createdAt).split("T")[0];
 
-          console.log(`변환된 doneDate: ${doneDate}, 타입: ${typeof doneDate}`);
-          console.log(`이번 주에 포함?: ${weekDates.includes(doneDate)}`);
-
           // 이번 주에 해당하는 날짜일시 해당 completions 값 업데이트
           if (weekDates.includes(doneDate)) {
-            console.log(`${doneDate}에 완료됨으로 표시`);
             completions[habit.id][doneDate] = true;
           }
         });

--- a/frontend/src/pages/study-detail/StudyContent.jsx
+++ b/frontend/src/pages/study-detail/StudyContent.jsx
@@ -1,14 +1,33 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import styles from "./StudyContent.module.css";
 import arrowIcon from "/images/icon/ic_arrow_right.svg";
 import { Link, useParams } from "react-router-dom";
+import { getStudyDetail } from "@api/study/studyDetail.api";
 
 const StudyContent = () => {
   const { studyId } = useParams();
+  const [study, setStudy] = useState({
+    title: "",
+    nickName: "",
+    description: "",
+    point: 0,
+  });
+  useEffect(() => {
+    const fetchStudyData = async () => {
+      try {
+        const studyData = await getStudyDetail(studyId);
+        setStudy(studyData);
+      } catch (error) {
+        console.error("Failed to fetch study details:", error);
+      }
+    };
+
+    fetchStudyData();
+  }, [studyId]);
   return (
     <div className={styles.contentWrapper}>
       <div className={styles.contentTop}>
-        <h1 className={styles.title}>지수의 개발공장</h1>
+        <h1 className={styles.title}>{study.title}</h1>
         <div className={styles.buttons}>
           {/* 임시 링크 태그임 비밀번호 요구하는 모달로 바꿔야함 */}
           <Link to={`/studies/${studyId}/focus`} className={styles.button}>
@@ -25,7 +44,7 @@ const StudyContent = () => {
       <div className={styles.contentBottom}>
         <div className={styles.intro}>
           <h2 className={styles.heading}>소개</h2>
-          <p className={styles.text}>오늘 하루도 화이팅</p>
+          <p className={styles.text}>{study.description}</p>
         </div>
 
         <div className={styles.points}>
@@ -36,7 +55,7 @@ const StudyContent = () => {
               alt="point icon"
               className={styles.pointIcon}
             />
-            <span className={styles.pointValue}>310P 획득</span>
+            <span className={styles.pointValue}>{study.point}P 획득</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 기능내용
- 해당 스터디 상세페이지에 관련한 내용 - 타이틀, 내용, 포인트를 불러옵니다.
- 습관 테이블에는 스터디가 가지고있는 습관 리스트를 불러오고, 유저가 습관을 했음으로 체크했을시에 색깔별로 스티커가 표시가 됩니다.
- 비밀번호 삭제시 일치하지 않으면 토스트 모달이 뜹니다.


## 상세내용
- 현재 삭제된 습관들은 불러오지지 않는 상황인데 이것은 습관쪽 담당하시는 세빈님이 백엔드부분 수정하고 있는 사항이라 그 부분까지 업데이트 된다면 삭제된 습관들도 기록표에 남아있을것 같습니다.
<img width="708" alt="Screenshot 2025-04-04 at 4 29 54 PM" src="https://github.com/user-attachments/assets/d4d8f996-f7ed-4b1a-8d87-a21cd5addd2f" />
<img width="751" alt="Screenshot 2025-04-04 at 4 34 41 PM" src="https://github.com/user-attachments/assets/f15ee5fd-fd20-4c90-879f-e8eb3d1ed7dc" />


close #67 