### PR TITLE
Fix/home 최근 조회한 스터디의 정렬 문제 및 최신 변경사항 미반영 문제 수정

### DIFF
--- a/frontend/public/images/icon/ic_plus.png:Zone.Identifier
+++ b/frontend/public/images/icon/ic_plus.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://www.figma.com/

--- a/frontend/src/api/home/getStudy.api.js
+++ b/frontend/src/api/home/getStudy.api.js
@@ -24,6 +24,22 @@ export const getStudies = async ({
   }
 };
 
+export const getRecentlyViewedStudies = async (studyIds) => {
+  const formattedStudyIds = studyIds.slice(1, -1);
+
+  try {
+    const response = await axiosInstance.get("/studies/recently", {
+      params: {
+        studyIds: formattedStudyIds,
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.error("Failed to fetch studies:", error);
+    throw error;
+  }
+};
+
 // 정렬 옵션 매핑
 export const SORT_OPTIONS = {
   "최근 순": { orderBy: "createAt", sort: "desc" },

--- a/frontend/src/components/home/HomeCard.jsx
+++ b/frontend/src/components/home/HomeCard.jsx
@@ -45,7 +45,6 @@ const HomeCard = ({ data }) => {
     }
   }, [data.background]);
 
-  // 이미지다
   return (
     <li
       className={styles.card}

--- a/frontend/src/components/home/HomeCard.module.css
+++ b/frontend/src/components/home/HomeCard.module.css
@@ -234,6 +234,9 @@
 }
 
 @media screen and (min-width: 744px) {
+  .card {
+    padding: 30px;
+  }
   .headerTop {
     justify-content: space-between;
     flex-direction: row-reverse;

--- a/frontend/src/pages/home/RecentlySection.jsx
+++ b/frontend/src/pages/home/RecentlySection.jsx
@@ -1,32 +1,63 @@
 import { useEffect, useState } from "react";
 import HomeCard from "@components/home/HomeCard";
 import styles from "./RecentlySection.module.css";
+import { getRecentlyViewedStudies } from "@api/home/getStudy.api";
+import { ClipLoader } from "react-spinners";
+
+// 로컬 스토리지에 데이터가 있는지 확인
+const HAS_CARD_ID = localStorage.getItem("studyForestCardIds");
 
 const RecentlySection = () => {
-  const [studyForestLocalStorageData, setStudyForestLocalStorageData] =
-    useState([]);
+  const [recentlyViewedStudies, setRecentlyViewedStudies] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    const data = localStorage.getItem("studyForest");
-    if (data) {
-      const parsedData = JSON.parse(data);
-      setStudyForestLocalStorageData(parsedData);
-    }
+    const data = localStorage.getItem("studyForestCardIds");
+
+    // 여기서 서버에서 카드 아이디에 따른 카드 데이터 조회하기 조회
+    const fetchRecentlyViewedStudies = async () => {
+      if (!data) {
+        return;
+      }
+
+      try {
+        setIsLoading(true);
+        const recentlyViewedStudies = await getRecentlyViewedStudies(data);
+        setRecentlyViewedStudies(recentlyViewedStudies);
+      } catch (error) {
+        console.error("최근 조회한 스터디 가져오기 실패:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchRecentlyViewedStudies();
   }, []);
+
   return (
     <div className={styles.recentStudyContainer}>
       <div className={styles.title}>최근 조회한 스터디</div>
 
-      {studyForestLocalStorageData.length > 0 ? (
-        <div className={styles.cardListContainer}>
-          <ul className={styles.cardList}>
-            {studyForestLocalStorageData.map((data) => (
-              <div key={`recently-${data.id}`} className={styles.cardWrapper}>
-                <HomeCard data={data} />
-              </div>
-            ))}
-          </ul>
-        </div>
+      {HAS_CARD_ID ? (
+        isLoading ? (
+          <div className={styles.loading}>
+            <ClipLoader size={100} color="#578246" loading={true} />
+          </div>
+        ) : recentlyViewedStudies.length > 0 ? (
+          <div className={styles.cardListContainer}>
+            <ul className={styles.cardList}>
+              {recentlyViewedStudies.map((data) => (
+                <div key={`recently-${data.id}`} className={styles.cardWrapper}>
+                  <HomeCard data={data} />
+                </div>
+              ))}
+            </ul>
+          </div>
+        ) : (
+          <div className={styles.noData}>
+            최근 조회한 스터디를 불러올 수 없습니다.
+          </div>
+        )
       ) : (
         <div className={styles.noData}>아직 조회한 스터디가 없습니다.</div>
       )}

--- a/frontend/src/pages/home/RecentlySection.module.css
+++ b/frontend/src/pages/home/RecentlySection.module.css
@@ -19,6 +19,13 @@
   transition: all 0.3s ease;
 }
 
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 380px;
+}
+
 .noData {
   display: flex;
   align-items: center;

--- a/frontend/src/utils/study.js
+++ b/frontend/src/utils/study.js
@@ -15,20 +15,31 @@ const loadMoreStudies = async (currentStudies, setStudies, setIsLoading) => {
   }
 };
 
-const saveAndNavigateToStudy = (study, navigate) => {
-  const storedData = localStorage.getItem("studyForest");
+const saveAndNavigateToStudy = (data, navigate) => {
+  const storedData = localStorage.getItem("studyForestCardIds");
   const parsedData = storedData ? JSON.parse(storedData) : [];
 
-  const isDuplicate = parsedData.some((item) => item.id === study.id);
+  const isDuplicate = parsedData.some((item) => item === data.id);
 
-  if (!isDuplicate) {
-    const newData = [study, ...parsedData];
+  if (isDuplicate) {
+    // 중복 제거
+    const filtered = parsedData.filter((id) => id !== data.id);
+
+    // 맨 앞에 추가
+    filtered.unshift(data.id);
+
+    // 가장 최근 10개 유지
+    const limited = filtered.slice(-10);
+
+    localStorage.setItem("studyForestCardIds", JSON.stringify(limited));
+  } else {
+    const newData = [data.id, ...parsedData];
     // 우선 최대 10개만
     const limitedData = newData.slice(0, 10);
-    localStorage.setItem("studyForest", JSON.stringify(limitedData));
+    localStorage.setItem("studyForestCardIds", JSON.stringify(limitedData));
   }
 
-  navigate(`/studies/${study.id}`);
+  navigate(`/studies/${data.id}`);
 };
 
 export { loadMoreStudies, saveAndNavigateToStudy };


### PR DESCRIPTION
## ✅ 변경 내용

- [x] 로컬스토리지에 카드 ID만 저장하도록 수정
  - 기존에는 카드 전체 데이터를 저장하여 서버 변경 사항 반영 불가
  - 이제는 ID만 저장하고, 서버에서 최신 데이터를 가져오는 방식으로 변경

- [x] 최근 조회한 스터디를 최신 순으로 정렬
  - 로컬스토리지 ID 순서를 기준으로 서버에서 받은 데이터를 정렬
  - 사용자가 본 순서 그대로 리스트가 렌더링됨
