### PR TITLE
fix : studyContent의 길이에 따라 카드 UI가 깨지는 문제 발생 -> line-clamp 속성으로 3줄 이상으로 나올 시 그 뒤는 ... 처리로 수정

### DIFF
--- a/frontend/src/pages/home/HomeCard.module.css
+++ b/frontend/src/pages/home/HomeCard.module.css
@@ -182,12 +182,22 @@
 .cardContentContainer {
   position: relative;
   z-index: 1;
-  width: 80%;
+  width: 100%;
 }
 
 .cardContent {
   font-size: 14px;
   color: var(--text-black);
+
+  display: -webkit-box;
+
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+
+  line-height: 1.4;
 }
 
 .card[data-bg^="bg5"] .cardContent,


### PR DESCRIPTION
### fix : studyContent의 길이에 따라 카드 UI가 깨지는 문제 발생 -> line-clamp 속성으로 3줄 이상으로 나올 시 그 뒤는 ... 처리로 수정
![image](https://github.com/user-attachments/assets/a058ba12-0d31-413a-aeff-07bed1f5f779)
